### PR TITLE
remove the cache from the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # pin@v1.227.0
         with:
-          bundler-cache: true
+          bundler-cache: false
 
       - name: bootstrap
         run: script/bootstrap


### PR DESCRIPTION
This pull request makes it so that the release process no longer caches the bundler cache.