### PR TITLE
Add Authorization Bearer token pattern

### DIFF
--- a/lib/patterns/default.rb
+++ b/lib/patterns/default.rb
@@ -47,6 +47,9 @@ module Patterns
     # Vault Tokens
     # https://github.com/hashicorp/vault/issues/27151
     /[sbr]\.[a-zA-Z0-9]{24,}/, # <= 1.9.x
-    /hv[sbr]\.[a-zA-Z0-9]{24,}/ # >= 1.10
+    /hv[sbr]\.[a-zA-Z0-9]{24,}/, # >= 1.10
+
+    # Authorization bearer tokens
+    /(?i)authorization:\s+bearer\s+[A-Za-z0-9\-_\.=~+\/]+/,
   ].freeze
 end

--- a/lib/patterns/default.rb
+++ b/lib/patterns/default.rb
@@ -50,6 +50,7 @@ module Patterns
     /hv[sbr]\.[a-zA-Z0-9]{24,}/, # >= 1.10
 
     # Authorization bearer tokens
+    # https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
     /(?i)authorization:\s+bearer\s+[A-Za-z0-9\-_\.=~+\/]+/,
   ].freeze
 end

--- a/spec/lib/redacting_logger_spec.rb
+++ b/spec/lib/redacting_logger_spec.rb
@@ -170,6 +170,41 @@ describe RedactingLogger do
         case: "redacts authorization bearer token with case insensitivity",
         message: '-H  "authorizAtion: beaRer ab123456789a1abcd1~_.-+456ABCDE=" -H "Content-Type: application/json"',
         expected_message: '-H  "[REDACTED]" -H "Content-Type: application/json"'
+      },
+      {
+        case: "redacts authorization bearer token with extra spaces and tabs",
+        message: "authorization:    bearer   abcd1234",
+        expected_message: "[REDACTED]"
+      },
+      {
+        case: "redacts authorization bearer token with special characters",
+        message: "authorization: bearer aBcD-_=~+/1234",
+        expected_message: "[REDACTED]"
+      },
+      {
+        case: "redacts authorization bearer token at start of string",
+        message: "authorization: bearer tokenatstart",
+        expected_message: "[REDACTED]"
+      },
+      {
+        case: "redacts authorization bearer token at end of string",
+        message: "some text authorization: bearer tokenatend",
+        expected_message: "some text [REDACTED]"
+      },
+      {
+        case: "redacts multiple authorization bearer tokens in one string",
+        message: "authorization: bearer token1 and authorization: bearer token2",
+        expected_message: "[REDACTED] and [REDACTED]"
+      },
+      {
+        case: "redacts authorization bearer token with minimum plausible length",
+        message: "authorization: bearer a",
+        expected_message: "[REDACTED]"
+      },
+      {
+        case: "redacts authorization bearer token with maximum plausible length",
+        message: "authorization: bearer #{'a' * 256}",
+        expected_message: "[REDACTED]"
       }
     ].each do |test|
       it "redacts #{test[:case]}" do

--- a/spec/lib/redacting_logger_spec.rb
+++ b/spec/lib/redacting_logger_spec.rb
@@ -165,6 +165,11 @@ describe RedactingLogger do
         case: "redacts authorization bearer token",
         message: '-H  "Authorization: Bearer ab123456789a1abcd1~_.-+456ABCDE=" -H "Content-Type: application/json"',
         expected_message: '-H  "[REDACTED]" -H "Content-Type: application/json"'
+      },
+      {
+        case: "redacts authorization bearer token with case insensitivity",
+        message: '-H  "authorizAtion: beaRer ab123456789a1abcd1~_.-+456ABCDE=" -H "Content-Type: application/json"',
+        expected_message: '-H  "[REDACTED]" -H "Content-Type: application/json"'
       }
     ].each do |test|
       it "redacts #{test[:case]}" do

--- a/spec/lib/redacting_logger_spec.rb
+++ b/spec/lib/redacting_logger_spec.rb
@@ -160,6 +160,11 @@ describe RedactingLogger do
         case: "redacts a RubyGems token",
         message: "using rubygems token: rubygems_0123456789abcdef0123456789abcdef0123456789abcdef",
         expected_message: "using rubygems token: [REDACTED]"
+      },
+      {
+        case: "redacts authorization bearer token",
+        message: '-H  "Authorization: Bearer ab123456789a1abcd1~_.-+456ABCDE=" -H "Content-Type: application/json"',
+        expected_message: '-H  "[REDACTED]" -H "Content-Type: application/json"'
       }
     ].each do |test|
       it "redacts #{test[:case]}" do


### PR DESCRIPTION
Pulled out from https://github.com/github/blackbird-mw/pull/3756.

This adds a regex pattern for redacting `Authorization: Bearer <token>`.