### PR TITLE
Fix ghs_ redaction pattern to support new token format

### DIFF
--- a/lib/patterns/default.rb
+++ b/lib/patterns/default.rb
@@ -12,7 +12,7 @@ module Patterns
     # https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
     /ghp_[A-Za-z0-9]{36,}|[0-9A-Fa-f]{40,}/,
     /github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}/, # Fine Grained
-    /ghs_[a-zA-Z0-9]{36}/, # Temporary Actions Tokens
+    /ghs_[A-Za-z0-9._]{36,}/, # GitHub App installation tokens
 
     # JWT Token
     # https://en.wikipedia.org/wiki/JSON_Web_Token

--- a/lib/patterns/default.rb
+++ b/lib/patterns/default.rb
@@ -12,7 +12,7 @@ module Patterns
     # https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
     /ghp_[A-Za-z0-9]{36,}|[0-9A-Fa-f]{40,}/,
     /github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}/, # Fine Grained
-    /ghs_[A-Za-z0-9._]{36,}/, # GitHub App installation tokens
+    /ghs_[A-Za-z0-9._-]{36,}/, # GitHub App installation tokens
 
     # JWT Token
     # https://en.wikipedia.org/wiki/JSON_Web_Token

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module RedactingLogger
   module Version
-    VERSION = "1.5.1"
+    VERSION = "1.5.2"
   end
 end

--- a/spec/lib/redacting_logger_spec.rb
+++ b/spec/lib/redacting_logger_spec.rb
@@ -92,6 +92,31 @@ describe RedactingLogger do
         expected_message: "token [REDACTED]"
       },
       {
+        case: "github app installation token with dashes",
+        message: "token ghs_Abcdef-1234567890-ghijklmnopqrstu-vwxyz",
+        expected_message: "token [REDACTED]"
+      },
+      {
+        case: "github app installation token with mixed special chars",
+        message: "token ghs_abc.DEF-123_ghi.JKL-456_mno.PQR-789_stu",
+        expected_message: "token [REDACTED]"
+      },
+      {
+        case: "github app installation token at minimum length (36 chars after prefix)",
+        message: "token ghs_abcdefghijklmnopqrstuvwxyz1234567890",
+        expected_message: "token [REDACTED]"
+      },
+      {
+        case: "github app installation token longer than 36 chars",
+        message: "token ghs_abcdefghijklmnopqrstuvwxyz1234567890.extra-chars_here.more",
+        expected_message: "token [REDACTED]"
+      },
+      {
+        case: "github app installation token too short to match",
+        message: "token ghs_tooshort",
+        expected_message: "token ghs_tooshort"
+      },
+      {
         case: "custom token",
         message: "token token_ABCDE",
         expected_message: "token [REDACTED]"

--- a/spec/lib/redacting_logger_spec.rb
+++ b/spec/lib/redacting_logger_spec.rb
@@ -82,9 +82,14 @@ describe RedactingLogger do
         expected_message: "token [REDACTED]"
       },
       {
-        case: "github action pat",
+        case: "github app installation token",
         message: "token ghs_1234567890abcdefghijklmnopqrstuvwxyz123456",
-        expected_message: "token [REDACTED]123456"
+        expected_message: "token [REDACTED]"
+      },
+      {
+        case: "github app installation token with dots and underscores",
+        message: "token ghs_Abcdef1234567890ghijklmnopqrstu.vw_xyz.1234567890",
+        expected_message: "token [REDACTED]"
       },
       {
         case: "custom token",


### PR DESCRIPTION
Updates the `ghs_` token regex to support the new token format which allows dots and underscores (`[A-Za-z0-9._]`) and variable length (no longer fixed at 36 chars).

See the changelog: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/